### PR TITLE
Show KStreams binder as a top-level section in the docs

### DIFF
--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-aggregate.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-aggregate.adoc
@@ -6,6 +6,10 @@ include::{stream-docs-basedir}/core/spring-cloud-stream-core-docs/src/main/ascii
 
 include::{stream-docs-basedir}/kafka/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/spring-cloud-stream-binder-kafka-aggregate.adoc[leveloffset=+1]
 
+== Apache Kafka Streams Binder
+
+include::{stream-docs-basedir}/kafka/spring-cloud-stream-binder-kafka-docs/src/main/asciidoc/kafka-streams.adoc[leveloffset=+1]
+
 == RabbitMQ Binder
 
 include::{stream-docs-basedir}/rabbit/spring-cloud-stream-binder-rabbit-docs/src/main/asciidoc/spring-cloud-stream-binder-rabbit-aggregate.adoc[leveloffset=+1]


### PR DESCRIPTION
Resolves spring-cloud/spring-cloud-stream-binder-kafka#317