### PR TITLE
Adding new schema registry coordinates to BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
 	<packaging>pom</packaging>
 	<name>spring-cloud-stream-release-build</name>
 	<description>Spring Cloud Stream Release Build</description>
-	<version>Germantown.BUILD-SNAPSHOT</version>
+	<version>Horsham.BUILD-SNAPSHOT</version>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>2.1.6.RELEASE</version>
+		<version>2.2.0.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 

--- a/spring-cloud-starter-parent/pom.xml
+++ b/spring-cloud-starter-parent/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.7.RELEASE</version>
+		<version>2.2.0.BUILD-SNAPSHOT</version>
 	</parent>
 	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-stream-starter-parent</artifactId>
-	<version>Germantown.BUILD-SNAPSHOT</version>
+	<version>Horsham.BUILD-SNAPSHOT</version>
 	<name>spring-cloud-stream-starter-parent</name>
 	<description>Specifies Boot version for the releaser</description>
 	<packaging>pom</packaging>

--- a/spring-cloud-stream-dependencies/pom.xml
+++ b/spring-cloud-stream-dependencies/pom.xml
@@ -6,19 +6,20 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>2.1.6.RELEASE</version>
+		<version>2.2.0.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-stream-dependencies</artifactId>
-	<version>Germantown.BUILD-SNAPSHOT</version>
+	<version>Horsham.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-stream-dependencies</name>
 	<description>Spring Cloud Stream Dependencies</description>
 	<properties>
-		<spring-cloud-stream.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-stream.version>
-		<spring-cloud-stream-binder-kafka.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-stream-binder-kafka.version>
-		<spring-cloud-stream-binder-rabbit.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-stream-binder-rabbit.version>
-		<spring-cloud-stream-dependencies.version>Germantown.BUILD-SNAPSHOT</spring-cloud-stream-dependencies.version>
+		<spring-cloud-stream.version>3.0.0.BUILD-SNAPSHOT</spring-cloud-stream.version>
+		<spring-cloud-stream-binder-kafka.version>3.0.0.BUILD-SNAPSHOT</spring-cloud-stream-binder-kafka.version>
+		<spring-cloud-stream-binder-rabbit.version>3.0.0.BUILD-SNAPSHOT</spring-cloud-stream-binder-rabbit.version>
+		<spring-cloud-schema-registry.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-schema-registry.version>
+		<spring-cloud-stream-dependencies.version>Horsham.BUILD-SNAPSHOT</spring-cloud-stream-dependencies.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -34,13 +35,18 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-schema</artifactId>
-				<version>${spring-cloud-stream.version}</version>
+				<artifactId>spring-cloud-schema-registry-core</artifactId>
+				<version>${spring-cloud-schema-registry.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-schema-server</artifactId>
-				<version>${spring-cloud-stream.version}</version>
+				<artifactId>spring-cloud-schema-registry-server</artifactId>
+				<version>${spring-cloud-schema-registry.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-schema-registry-client</artifactId>
+				<version>${spring-cloud-schema-registry.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
Schema Registry artifacts have migrated from core spring-cloud-stream repository.
Include the new maven coordinates in the BOM.
Update versions to Horsham.BUILD-SNAPSHOT.

Resolves #99